### PR TITLE
Remove unused dependencies

### DIFF
--- a/Examples/pom.xml
+++ b/Examples/pom.xml
@@ -17,6 +17,52 @@
       <groupId>cz.abclinuxu.datoveschranky</groupId>
       <artifactId>ISDS</artifactId>
       <version>1.0-SNAPSHOT</version>
+      <exclusions>
+        <exclusion>
+          <groupId>javax.xml.ws</groupId>
+          <artifactId>jaxws-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.messaging.saaj</groupId>
+          <artifactId>saaj-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.stream</groupId>
+          <artifactId>sjsxp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.stream.buffer</groupId>
+          <artifactId>streambuffer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.org.apache.xml.internal</groupId>
+          <artifactId>resolver</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.bind</groupId>
+          <artifactId>jaxb-impl</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.xml.bind</groupId>
+          <artifactId>jaxb-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.activation</groupId>
+          <artifactId>activation</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>javax.xml.stream</groupId>
+          <artifactId>stax-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.sun.xml.ws</groupId>
+          <artifactId>jaxws-rt</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
@xrosecky Hi, I am a user of project **_cz.abclinuxu.datoveschranky:Examples:1.0-SNAPSHOT_**. I found that its pom file introduced **_25_** dependencies. However, among them, **_13_** libraries (**_52%_**) have not been used by your project (the redundant dependencies are listed below). This PR helps **_cz.abclinuxu.datoveschranky:Examples:1.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
com.sun.xml.messaging.saaj:saaj-impl:jar:1.3.1:compile
com.sun.org.apache.xml.internal:resolver:jar:20050927:compile
com.sun.xml.stream:sjsxp:jar:1.0.1:compile
com.sun.xml.bind:jaxb-impl:jar:2.1.7:compile
commons-codec:commons-codec:jar:1.3:compile
javax.xml.ws:jaxws-api:jar:2.1:compile
javax.activation:activation:jar:1.1:compile
org.jvnet.staxex:stax-ex:jar:1.2:compile
com.sun.xml.stream.buffer:streambuffer:jar:0.7:compile
com.sun.xml.ws:jaxws-rt:jar:2.1.4:compile
javax.xml.bind:jaxb-api:jar:2.1:compile
javax.xml.soap:saaj-api:jar:1.3:compile
javax.xml.stream:stax-api:jar:1.0:compile
</code></pre>